### PR TITLE
Don't disconnect from read pool after every call

### DIFF
--- a/activerecord_autoreplica.gemspec
+++ b/activerecord_autoreplica.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "activerecord_autoreplica"
-  s.version = "1.1.0"
+  s.version = "1.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]


### PR DESCRIPTION
- add memoization of the custom `ConnectionHandler`
- replace `disconnect_read_pool!` by `release_connection`
- make `resolve_connection_url` private
- extract swapping `ActiveRecord::Base.connection_handler` logic into private method
